### PR TITLE
Implement selecting audio by category and title

### DIFF
--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Actions/PlayAction.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Actions/PlayAction.cs
@@ -19,6 +19,10 @@ namespace PW.MacroDeck.SoundPad.Actions
 
         public override ActionConfigControl GetActionConfigControl(ActionConfigurator actionConfigurator)
         {
+            if (!SoundPadManager.IsConnected)
+            {
+                return new Views.NotConnectedConfigView();
+            }
             return new Views.PlayActionConfigView(this);
         }
 

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/MacroDeck.SoundPad.csproj
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/MacroDeck.SoundPad.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<VersionMajor>0</VersionMajor>
-		<VersionMinor>1</VersionMinor>
-		<VersionPatch>2</VersionPatch>
+		<VersionMinor>2</VersionMinor>
+		<VersionPatch>0</VersionPatch>
 		<VersionRevision Condition="'$(VersionRevision)' == ''">$([System.DateTime]::UtcNow.ToString("yy"))$([System.DateTime]::UtcNow.DayOfYear.ToString("000")).$([System.DateTime]::UtcNow.ToString("HHmm"))</VersionRevision>
 	</PropertyGroup>
 	
@@ -62,6 +62,9 @@
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>Resources.resx</DependentUpon>
+		</Compile>
+		<Compile Update="Views\NotConnectedConfigView.cs">
+		  <SubType>UserControl</SubType>
 		</Compile>
 	</ItemGroup>
 

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/Localization.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/Localization.cs
@@ -9,6 +9,8 @@
         public string Disconnected { get; set; } = "SoundPad Disconnected";
         public string PlayActionName { get; set; } = "Play";
         public string PlayActionDescription { get; set; } = "Play a sound";
-        public string PlayActionAudioIndex { get; set; } = "Audio index";
+        public string PlayActionCategory { get; set; } = "Category";
+        public string PlayActionSoundTitle { get; set; } = "Sound title";
+        public string PleaseConnect { get; set; } = "Please ensure Soundpad is open and connected, then try again.";
     }
 }

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/PlayActionConfigModel.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/PlayActionConfigModel.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 
 namespace PW.MacroDeck.SoundPad.Models
 {
+    [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
     public class PlayActionConfigModel : ISerializableConfiguration
     {
-        public int AudioIndex { get; set; } = 1;
+        public int AudioIndex { get; set; }
+        public SoundpadSound Sound { get; set; }
+        public SoundpadCategory Category { get; set; }
 
         public string Serialize()
         {
@@ -17,6 +21,16 @@ namespace PW.MacroDeck.SoundPad.Models
         public static PlayActionConfigModel Deserialize(string config)
         {
             return ISerializableConfiguration.Deserialize<PlayActionConfigModel>(config);
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            return ToString();
+        }
+
+        public override string ToString()
+        {
+            return $"{Category.Name}: {Sound.Title}";
         }
     }
 }

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/SoundpadCategory.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/SoundpadCategory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace PW.MacroDeck.SoundPad.Models
+{
+    [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
+    public class SoundpadCategory
+    {
+        public int Index { get; set; }
+        
+        public string Name { get; set; }
+
+        public int Type { get; set; }
+        
+        public SoundpadCategory() { } //required for serialization in config model
+
+        public SoundpadCategory(SoundpadConnector.XML.Category category)
+        {
+            Index = category.Index;
+            Name = category.Name;
+            Type = category.Type;
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            return $"{Index}. {Name} - {Type}";
+        }
+    }
+}

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/SoundpadSound.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Models/SoundpadSound.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace PW.MacroDeck.SoundPad.Models
+{
+    [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
+    public class SoundpadSound
+    {
+        public int Index { get; set; }
+        
+        public string Title { get; set; }
+
+        public SoundpadSound() { } //required for serialization in config model
+
+        public SoundpadSound(SoundpadConnector.XML.Sound sound)
+        {
+            Index = sound.Index;
+            Title = sound.Title;
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            return $"{Index}: {Title}";
+        }
+    }
+}

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Services/SoundPadManager.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Services/SoundPadManager.cs
@@ -36,7 +36,8 @@ namespace PW.MacroDeck.SoundPad.Services
         {
             if (IsConnected)
             {
-                int index = PlayActionConfigModel.Deserialize(config).AudioIndex;
+                var actionConfig = PlayActionConfigModel.Deserialize(config);
+                int index = actionConfig.Sound?.Index ?? actionConfig.AudioIndex;
                 Soundpad.PlaySound(index);
             }
         }

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/ViewModels/PlayActionConfigViewModel.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/ViewModels/PlayActionConfigViewModel.cs
@@ -1,9 +1,12 @@
 ﻿using PW.MacroDeck.SoundPad.Models;
+using PW.MacroDeck.SoundPad.Services;
 using SuchByte.MacroDeck.Logging;
 using SuchByte.MacroDeck.Plugins;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace PW.MacroDeck.SoundPad.ViewModels
 {
@@ -14,18 +17,34 @@ namespace PW.MacroDeck.SoundPad.ViewModels
         ISerializableConfiguration ISerializableConfigViewModel.SerializableConfiguration => Configuration;
 
         public PlayActionConfigModel Configuration { get; set; }
-        public int AudioIndex 
+
+        private int AudioIndex 
         {
             get => Configuration.AudioIndex;
             set => Configuration.AudioIndex = value;
         }
+
+        public SoundpadSound Sound
+        {
+            get => Configuration.Sound;
+            set => Configuration.Sound = value;
+        }
+
+        public SoundpadCategory Category
+        {
+            get => Configuration.Category;
+            set => Configuration.Category = value;
+        }
+
+        public List<SoundpadCategory> Categories { get; set; }
+
+        public List<SoundpadSound> Sounds { get; set; }
 
         public PlayActionConfigViewModel(PluginAction action)
         {
             Configuration = PlayActionConfigModel.Deserialize(action.Configuration);
             _action = action;
         }
-
         public void SaveConfig()
         {
             try
@@ -42,8 +61,72 @@ namespace PW.MacroDeck.SoundPad.ViewModels
 
         public void SetConfig()
         {
-            _action.ConfigurationSummary = Configuration.AudioIndex.ToString();
+            _action.ConfigurationSummary = Configuration.ToString();
             _action.Configuration = Configuration.Serialize();
+        }
+
+        public void ChangeSound(string audioTitle = default)
+        {
+            if (!string.IsNullOrEmpty(audioTitle))
+            {
+                Sound = Sounds.First(s => s.Title.Equals(audioTitle));
+            }
+
+            if (Sound != null && !Sounds.Any(s => s.Equals(Sound)))
+            {
+                Sound = Sounds.First(s => s.Title.Equals(Sound.Title)) ?? Sounds.First(s => s.Index.Equals(Sound.Index));
+            }
+            
+            if (Sound == null && AudioIndex > 0)
+            {
+                Sound = Sounds.First(s => s.Index.Equals(AudioIndex));
+            }
+
+            AudioIndex = Sound.Index;
+        }
+
+        public void ChangeCategory(string categoryName = default)
+        {
+            if (!string.IsNullOrEmpty(categoryName))
+            {
+                Category = Categories.First(c => c.Name.Equals(categoryName));
+            }
+
+            if (Category != null && !Categories.Any(c => c.Equals(Category)))
+            {
+                Category = Categories.First(c => c.Name.Equals(Category.Name)) ?? Categories.First(c => c.Index.Equals(Category.Index));
+            }
+            //separate condition in case changed to null (ie. category changed in Name and Index)
+            if (Category == null)
+            {
+                Category = Categories.First(c => c.Type == 1);
+            }
+        }
+
+        public async Task FetchCategoriesAsync()
+        {
+            var categories = await SoundPadManager.Soundpad.GetCategories();
+            Categories = categories.Value.Categories.Select(c => new SoundpadCategory(c)).ToList();
+        }
+
+        public async Task FetchSoundListAsync(string categoryName = default)
+        {
+            var soundList = await FetchSoundsAsync(categoryName);
+            if (soundList != null)
+            {
+                Sounds = soundList.Select(s => new SoundpadSound(s)).ToList();
+            }
+        }
+
+        private async Task<List<SoundpadConnector.XML.Sound>> FetchSoundsAsync(string categoryName = default)
+        {
+            if (string.IsNullOrEmpty(categoryName) || Categories.First(c => c.Name.Equals(categoryName)).Type == 1)
+            {
+                var soundlist = await SoundPadManager.Soundpad.GetSoundlist();
+                return soundlist.Value.Sounds;
+            }
+            var category = await SoundPadManager.Soundpad.GetCategory(Categories.First(c => c.Name.Equals(categoryName)).Index, withSounds: true);
+            return category.Value.Sounds;
         }
     }
 }

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/NotConnectedConfigView.Designer.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/NotConnectedConfigView.Designer.cs
@@ -1,0 +1,59 @@
+﻿namespace PW.MacroDeck.SoundPad.Views
+{
+    partial class NotConnectedConfigView
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.labelMessage = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // labelMessage
+            // 
+            this.labelMessage.AutoSize = true;
+            this.labelMessage.Location = new System.Drawing.Point(62, 47);
+            this.labelMessage.Name = "labelMessage";
+            this.labelMessage.Size = new System.Drawing.Size(84, 23);
+            this.labelMessage.TabIndex = 0;
+            this.labelMessage.Text = "Please open Soundpad";
+            this.labelMessage.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // NotConnectedConfigView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.labelMessage);
+            this.Name = "NotConnectedConfigView";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelMessage;
+    }
+}

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/NotConnectedConfigView.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/NotConnectedConfigView.cs
@@ -1,0 +1,30 @@
+﻿using PW.MacroDeck.SoundPad.Services;
+using PW.MacroDeck.SoundPad.ViewModels;
+using SuchByte.MacroDeck.GUI.CustomControls;
+using SuchByte.MacroDeck.Plugins;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace PW.MacroDeck.SoundPad.Views
+{
+    public partial class NotConnectedConfigView : ActionConfigControl
+    {
+        public NotConnectedConfigView()
+        {
+            InitializeComponent();
+            ApplyLocalization();
+        }
+
+        private void ApplyLocalization()
+        {
+            labelMessage.Text = LocalizationManager.Instance.PleaseConnect;
+        }
+
+    }
+}

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/NotConnectedConfigView.resx
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/NotConnectedConfigView.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/PlayActionConfigView.Designer.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/PlayActionConfigView.Designer.cs
@@ -28,55 +28,60 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.audioIndexLabel = new System.Windows.Forms.Label();
-            this.audioIndex = new System.Windows.Forms.NumericUpDown();
-            ((System.ComponentModel.ISupportInitialize)(this.audioIndex)).BeginInit();
+            this.labelCategory = new System.Windows.Forms.Label();
+            this.categoryNames = new System.Windows.Forms.ComboBox();
+            this.audioTitles = new System.Windows.Forms.ComboBox();
+            this.labelSoundTitle = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
-            // audioIndexLabel
+            // labelCategory
             // 
-            this.audioIndexLabel.AutoSize = true;
-            this.audioIndexLabel.Location = new System.Drawing.Point(62, 47);
-            this.audioIndexLabel.Name = "audioIndexLabel";
-            this.audioIndexLabel.Size = new System.Drawing.Size(108, 23);
-            this.audioIndexLabel.TabIndex = 0;
-            this.audioIndexLabel.Text = "Audio index";
-            this.audioIndexLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.labelCategory.AutoSize = true;
+            this.labelCategory.Location = new System.Drawing.Point(62, 47);
+            this.labelCategory.Name = "labelCategory";
+            this.labelCategory.Size = new System.Drawing.Size(84, 23);
+            this.labelCategory.TabIndex = 0;
+            this.labelCategory.Text = "Category";
+            this.labelCategory.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // audioIndex
+            // categoryNames
             // 
-            this.audioIndex.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.audioIndex.Location = new System.Drawing.Point(176, 45);
-            this.audioIndex.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.audioIndex.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.audioIndex.Name = "audioIndex";
-            this.audioIndex.Size = new System.Drawing.Size(68, 27);
-            this.audioIndex.TabIndex = 1;
-            this.audioIndex.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.audioIndex.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.audioIndex.ValueChanged += new System.EventHandler(this.AudioIndex_ValueChanged);
+            this.categoryNames.FormattingEnabled = true;
+            this.categoryNames.Location = new System.Drawing.Point(205, 44);
+            this.categoryNames.Name = "categoryNames";
+            this.categoryNames.Size = new System.Drawing.Size(276, 31);
+            this.categoryNames.TabIndex = 2;
+            this.categoryNames.SelectedIndexChanged += new System.EventHandler(this.CategoryNames_SelectedIndexChanged);
+            // 
+            // audioTitles
+            // 
+            this.audioTitles.FormattingEnabled = true;
+            this.audioTitles.Location = new System.Drawing.Point(205, 81);
+            this.audioTitles.Name = "audioTitles";
+            this.audioTitles.Size = new System.Drawing.Size(276, 31);
+            this.audioTitles.TabIndex = 3;
+            this.audioTitles.SelectedIndexChanged += new System.EventHandler(this.AudioTitles_SelectedIndexChanged);
+            // 
+            // labelSoundTitle
+            // 
+            this.labelSoundTitle.AutoSize = true;
+            this.labelSoundTitle.Location = new System.Drawing.Point(62, 84);
+            this.labelSoundTitle.Name = "labelSoundTitle";
+            this.labelSoundTitle.Size = new System.Drawing.Size(105, 23);
+            this.labelSoundTitle.TabIndex = 5;
+            this.labelSoundTitle.Text = "Sound Title";
+            this.labelSoundTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // PlayActionConfigView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.audioIndex);
-            this.Controls.Add(this.audioIndexLabel);
+            this.Controls.Add(this.labelSoundTitle);
+            this.Controls.Add(this.audioTitles);
+            this.Controls.Add(this.categoryNames);
+            this.Controls.Add(this.labelCategory);
             this.Name = "PlayActionConfigView";
             this.Load += new System.EventHandler(this.PlayActionConfigView_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.audioIndex)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -84,7 +89,9 @@
 
         #endregion
 
-        private System.Windows.Forms.Label audioIndexLabel;
-        private System.Windows.Forms.NumericUpDown audioIndex;
+        private System.Windows.Forms.Label labelCategory;
+        private System.Windows.Forms.ComboBox categoryNames;
+        private System.Windows.Forms.ComboBox audioTitles;
+        private System.Windows.Forms.Label labelSoundTitle;
     }
 }

--- a/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/PlayActionConfigView.cs
+++ b/MacroDeck.SoundPad/MacroDeck.SoundPad/Views/PlayActionConfigView.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
@@ -15,6 +16,7 @@ namespace PW.MacroDeck.SoundPad.Views
     public partial class PlayActionConfigView : ActionConfigControl
     {
         private readonly PlayActionConfigViewModel _viewModel;
+        private bool _isBusy;
         public PlayActionConfigView(PluginAction action)
         {
             _viewModel = new PlayActionConfigViewModel(action);
@@ -25,7 +27,8 @@ namespace PW.MacroDeck.SoundPad.Views
 
         private void ApplyLocalization()
         {
-            audioIndexLabel.Text = LocalizationManager.Instance.PlayActionAudioIndex;
+            labelCategory.Text = LocalizationManager.Instance.PlayActionCategory;
+            labelSoundTitle.Text = LocalizationManager.Instance.PlayActionSoundTitle;
         }
 
         public override bool OnActionSave()
@@ -35,14 +38,34 @@ namespace PW.MacroDeck.SoundPad.Views
             return base.OnActionSave();
         }
 
-        private void PlayActionConfigView_Load(object sender, EventArgs e)
+        private async void PlayActionConfigView_Load(object sender, EventArgs e)
         {
-            audioIndex.Value = _viewModel.AudioIndex;
+            await _viewModel.FetchCategoriesAsync();
+            categoryNames.Items.Clear();
+            categoryNames.Items.AddRange(_viewModel.Categories.Select(c => c.Name).ToArray());
+            _viewModel.ChangeCategory();
+            _isBusy = true;
+            categoryNames.SelectedItem = _viewModel.Category.Name; //calls CategoryNames_SelectedIndexChanged
+            while (_isBusy) //Poll _isBusy until previous call is finished otherwise ChangeSound breaks due to null exception. 
+            {
+                await System.Threading.Tasks.Task.Delay(25);
+            }
+            _viewModel.ChangeSound();
+            audioTitles.SelectedItem = _viewModel.Sound.Title; //calls AudioTitles_SelectedIndexChanged
         }
 
-        private void AudioIndex_ValueChanged(object sender, EventArgs e)
+        private async void CategoryNames_SelectedIndexChanged(object sender, EventArgs e)
         {
-            _viewModel.AudioIndex = (int)audioIndex.Value;
+            _viewModel.ChangeCategory((string)categoryNames.SelectedItem);
+            await _viewModel.FetchSoundListAsync((string)categoryNames.SelectedItem);
+            audioTitles.Items.Clear();
+            audioTitles.Items.AddRange(_viewModel.Sounds.Select(a => a.Title).ToArray());
+            _isBusy = false;
+        }
+
+        private void AudioTitles_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            _viewModel.ChangeSound((string)audioTitles.SelectedItem);
         }
     }
 }


### PR DESCRIPTION
- fix #3 with ability to select audio by category and title. 
- AudioIndex removed since this is now found automatically, not chosen.
- add "not connected" screen if trying to edit a button when Soundpad is not open or connected.